### PR TITLE
Update debian base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM debian:stable
 MAINTAINER Exasol AG
 
 # install packages


### PR DESCRIPTION
debian:testing is no longer handling python path in the same way causing some scripts to not function. 